### PR TITLE
Fix rake tasks so it runs on linux CI server

### DIFF
--- a/lib/opal/rspec/rake_task.rb
+++ b/lib/opal/rspec/rake_task.rb
@@ -28,7 +28,7 @@ module Opal
               :Logger => WEBrick::Log.new("/dev/null"))
           end
 
-          # phantomjs tries to hit page before opalserver on my linux CI server
+          # phantomjs tries to hit page before OpalServer starts on my linux CI server
           sleep 1 if RUBY_PLATFORM =~ /linux/
 
           system "phantomjs #{RUNNER} \"#{URL}\""


### PR DESCRIPTION
PhantomJS was hitting the page before OpalServer spun up, failing the rake tasks.  Add a delay if linux.
