### PR TITLE
Named subject

### DIFF
--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -87,10 +87,14 @@ describe "subject" do
 end
 
 describe "named subject" do
-  subject(:array) { [1, 2, 3] }
+  subject(:named_subject) { [1, 2, 3] }
 
   it "should be the subject" do
     subject.should be_kind_of(Array)
+  end
+
+  it "should be the named subject" do
+    subject.should eql(named_subject)
   end
 end
 


### PR DESCRIPTION
I've got some specs that use the "named subject" syntax

``` ruby
subject(:name) { Foo.new }
```

opal-rspec doesn't like this syntax, though. This pull request adds some failing specs for that syntax. I'd love some guidance about how to make the spec pass.

```
$ bundle exec rake

Failures:


  1) named subject should be the subject
     NotImplementedError:
       `super` in named subjects is not supported


  2) named subject should be the named subject
     NotImplementedError:
       `super` in named subjects is not supported

61 examples, 2 failures (time taken: 1.105)
```
