### PR TITLE
Add examples for one-liner syntax

### DIFF
--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -136,6 +136,20 @@ describe "expect syntax" do
   end
 end
 
+describe "one-liner syntax" do
+  subject { 42 }
+
+  describe "is_expected" do
+    it { is_expected.to eq(42) }
+    it { is_expected.to_not eq(43) }
+  end
+
+  describe "should" do
+    it { should == 42 }
+    it { should_not == 43 }
+  end
+end
+
 describe "Normal errors" do
   it "should still work" do
     lambda { raise "wtf son" }.should raise_error(Exception)


### PR DESCRIPTION
RSpec's "is_expected" syntax isn't currently supported. The one-liner "should" syntax seems to be supported, but isn't included in the specs. This pull request adds specs for both one-liner styles.
- "should" syntax passes
- "is_expected" syntax fails

```
$ bundle exec rake

Failures:


  1) one-liner syntax is_expected
     NoMethodError:
       undefined method `is_expected' for #<RSpec::ExampleGroups::OneLinerSyntax::IsExpected:1325>


  2) one-liner syntax is_expected
     NoMethodError:
       undefined method `is_expected' for #<RSpec::ExampleGroups::OneLinerSyntax::IsExpected:1333>

63 examples, 2 failures (time taken: 1.101)
```

I'd love to add this feature, but I'm having trouble tracing the root issue. The `is_expected` method seems to be defined [in the same file](https://github.com/rspec/rspec-core/blob/v3.0.0.beta2/lib/rspec/core/memoized_helpers.rb) as `should`.

Any advice on how to approach this?
