### PR TITLE
Remove tricky auto load path functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ You can also customize the pattern of specs used similiar to how RSpec's rake ta
 Opal::RSpec::RakeTask.new(:default) do |server, task|
   # server is an instance of Opal::Server in case you want to add to the load path, customize, etc.
   task.pattern = 'spec_alternate/**/*_spec.rb' # can also supply an array of patterns
+  # NOTE: opal-rspec, like rspec, only adds 'spec' to the Opal load path unless you set default_path
+  task.default_path = 'spec_alternate'
 end
 ```
 
@@ -221,31 +223,7 @@ Disadvantages:
 
 ## Opal load path
 
-NOTE: Only the deepest directory specified will be added to the Opal load path.
-
-Example 1: For the example patterns above, only 'spec_alternate' will be added.
-
-Example 2: Single base path
-
-For a pattern of:
-
-```ruby
-'spec/other/**/*spec.rb'
-```
-
-'spec/other' will be added to the load path.
-
-Example 3: Different base paths
-
-Multiple patterns are specified that share the same parent:
-
-For a pattern of:
-
-```ruby
-['spec/opal/**/*hooks_spec.rb', 'spec/other/**/*_spec.rb']
-```
-
-Only 'spec' will be added to the load path.
+NOTE: Only the 'spec' directory will be added to the Opal load path by default. Use the Rake task's 'default_path' setting to change that
 
 ## Other Limitations/Known Issues
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,7 @@ task :default => [:unit_specs, :verify_opal_specs, :integration_specs, :verify_r
 desc 'Runs a set of specs in opal'
 Opal::RSpec::RakeTask.new(:opal_specs) do |_, task|
   task.pattern = 'spec/opal/**/*_spec.{rb,opal}'
+  task.default_path = 'spec/opal'
 end
 
 desc 'Generates an RSpec requires file free of dynamic requires'
@@ -36,10 +37,12 @@ end
 desc 'A more limited spec suite to test pattern usage'
 Opal::RSpec::RakeTask.new(:other_specs) do |_, task|
   task.pattern = 'spec/other/dummy_spec.rb'
+  task.default_path = 'spec/other'
 end
 
 Opal::RSpec::RakeTask.new(:color_on_by_default) do |_, task|
   task.pattern = 'spec/other/color_on_by_default_spec.rb'
+  task.default_path = 'spec/other'
 end
 
 Opal::RSpec::CoreSpecLoader.rake_tasks_for(:rspec_core_specs)

--- a/config.ru
+++ b/config.ru
@@ -2,11 +2,14 @@ require 'opal/rspec'
 
 Opal::Processor.source_map_enabled = false
 
-sprockets_env = Opal::RSpec::SprocketsEnvironment.new(spec_pattern='spec/opal/**/*_spec.{rb,opal}')
+sprockets_env = Opal::RSpec::SprocketsEnvironment.new(spec_pattern='spec/opal/**/*_spec.{rb,opal}',
+                                                      spec_exclude_pattern=nil,
+                                                      spec_files=nil,
+                                                      default_path='spec/opal')
 run Opal::Server.new(sprockets: sprockets_env) { |s|
-  s.main = 'sprockets_runner_js_errors'
-  # sprockets_runner_js_errors will not be in the opal load path by default
-  s.append_path 'spec/mri/integration/rack'
-  sprockets_env.add_spec_paths_to_sprockets
-  s.debug = ENV['OPAL_DEBUG']
-}
+      s.main = 'sprockets_runner_js_errors'
+      # sprockets_runner_js_errors will not be in the opal load path by default
+      s.append_path 'spec/mri/integration/rack'
+      sprockets_env.add_spec_paths_to_sprockets
+      s.debug = ENV['OPAL_DEBUG']
+    }

--- a/lib/opal/rspec/post_rack_locator.rb
+++ b/lib/opal/rspec/post_rack_locator.rb
@@ -11,7 +11,7 @@ module Opal
 
       def get_opal_spec_requires
         files = @spec_files || FileList[*@spec_pattern].exclude(*@spec_exclude_pattern)
-        files.map do |file|
+        files.uniq.map do |file|
           File.expand_path file
         end
       end

--- a/lib/opal/rspec/pre_rack_locator.rb
+++ b/lib/opal/rspec/pre_rack_locator.rb
@@ -1,67 +1,29 @@
 require 'pathname'
+require 'rspec/core/ruby_project'
 
 module Opal
   module RSpec
     class PreRackLocator
+      include ::RSpec::Core::RubyProject
+
       DEFAULT_PATTERN = 'spec/**/*_spec.{rb,opal}'
+      DEFAULT_DEFAULT_PATH = 'spec'
 
-      attr_accessor :spec_pattern, :spec_exclude_pattern, :spec_files
+      attr_accessor :spec_pattern, :spec_exclude_pattern, :spec_files, :default_path
 
-      def initialize(spec_pattern=nil, spec_exclude_pattern=nil, spec_files=nil)
+      def initialize(spec_pattern=nil, spec_exclude_pattern=nil, spec_files=nil, default_path=nil)
         @spec_pattern = spec_pattern || DEFAULT_PATTERN
         @spec_exclude_pattern = spec_exclude_pattern
         @spec_files = spec_files
+        @default_path = default_path || DEFAULT_DEFAULT_PATH
+      end
+
+      def determine_root
+        find_first_parent_containing(@default_path) || '.'
       end
 
       def get_spec_load_paths
-        base_paths = spec_files ? get_files_directories : strip_globs_from_patterns
-        # Want to get the smallest # of load paths that's common between our patterns
-        array_or_single = base_paths.inject do |path1, path2|
-          with_common_paths_replaced path1, path2
-        end
-        [*array_or_single]
-      end
-
-      private
-
-      def strip_globs_from_patterns
-        # only using spec_pattern here since we only need paths for inclusion
-        [*spec_pattern].map do |each_pattern|
-          glob_portion = /[\*\?\[\{].*/.match each_pattern
-          path = glob_portion ? each_pattern.sub(glob_portion.to_s, '') : each_pattern
-          raise "Unable to identify a single root directory/file in the pattern #{each_pattern}. Please adjust glob" unless File.exist?(path)
-          path = Pathname.new path
-          # in case a filename was used as a pattern
-          path.directory? ? path : path.dirname
-        end
-      end
-
-      def get_files_directories
-        spec_files.map do |file|
-          Pathname.new(file).dirname
-        end.uniq
-      end
-
-      def with_common_paths_replaced(existing_paths, new_path)
-        new_path_covered = false
-        replaced = [*existing_paths].map do |path|
-          match = nil
-          path.ascend do |each_level|
-            new_path.ascend do |each_other_level|
-              match = each_level if each_level.expand_path == each_other_level.expand_path
-              break if match
-            end
-            break if match
-          end
-          if match
-            new_path_covered = true
-            match
-          else
-            path
-          end
-        end
-        replaced << new_path unless new_path_covered
-        replaced.uniq
+        [@default_path].map { |dir| File.join(root, dir) }
       end
     end
   end

--- a/lib/opal/rspec/rake_task.rb
+++ b/lib/opal/rspec/rake_task.rb
@@ -11,7 +11,7 @@ module Opal
       PORT = 9999
       URL = "http://localhost:#{PORT}/"
 
-      attr_accessor :pattern, :exclude_pattern, :files, :runner, :timeout
+      attr_accessor :pattern, :exclude_pattern, :files, :default_path, :runner, :timeout
 
       def launch_phantom(timeout_value)
         command_line = %Q{phantomjs #{RUNNER} "#{URL}"#{timeout_value ? " #{timeout_value}" : ''}}
@@ -93,6 +93,7 @@ module Opal
             sprockets_env.spec_pattern = self.pattern if self.pattern
             sprockets_env.spec_exclude_pattern = self.exclude_pattern
             sprockets_env.spec_files = self.files
+            sprockets_env.default_path = self.default_path if self.default_path
             raise 'Cannot supply both a pattern and files!' if self.files and self.pattern
             sprockets_env.add_spec_paths_to_sprockets
           }

--- a/lib/opal/rspec/sprockets_environment.rb
+++ b/lib/opal/rspec/sprockets_environment.rb
@@ -16,10 +16,12 @@ module Opal
                      :spec_exclude_pattern=,
                      :spec_exclude_pattern,
                      :spec_files=,
-                     :spec_files
+                     :spec_files,
+                     :default_path=,
+                     :default_path
 
-      def initialize(spec_pattern=nil, spec_exclude_pattern=nil, spec_files=nil)
-        @locator = RSpec::PreRackLocator.new spec_pattern, spec_exclude_pattern, spec_files
+      def initialize(spec_pattern=nil, spec_exclude_pattern=nil, spec_files=nil, default_path=nil)
+        @locator = RSpec::PreRackLocator.new spec_pattern, spec_exclude_pattern, spec_files, default_path
         super()
       end
 

--- a/spec/mri/unit/opal/rspec/cached_environment_spec.rb
+++ b/spec/mri/unit/opal/rspec/cached_environment_spec.rb
@@ -6,10 +6,11 @@ require_relative 'temp_dir_helper'
 describe Opal::RSpec::CachedEnvironment do
   let(:pattern) { nil }
   let(:exclude_pattern) { nil }
+  let(:default_path) { nil }
   let(:files) { nil }
   include_context :temp_dir
 
-  let(:original_env) { Opal::RSpec::SprocketsEnvironment.new pattern, exclude_pattern, files }
+  let(:original_env) { Opal::RSpec::SprocketsEnvironment.new pattern, exclude_pattern, files, default_path }
 
   subject(:env) do
     # in subject to allow contexts to execute before logic
@@ -20,54 +21,35 @@ describe Opal::RSpec::CachedEnvironment do
   describe '#get_opal_spec_requires' do
     subject { env.get_opal_spec_requires.sort }
 
-    context '1 path' do
+    context 'no default path set' do
       before do
         create_dummy_spec_files 'spec/foobar/dummy_spec.rb', 'spec/foobar/ignored_spec.opal'
       end
 
       let(:pattern) { 'spec/foobar/**/*_spec.rb' }
 
+      it { is_expected.to eq ['foobar/dummy_spec'] }
+    end
+
+    context 'default path set' do
+      before do
+        create_dummy_spec_files 'spec/foobar/dummy_spec.rb', 'spec/foobar/ignored_spec.opal'
+      end
+
+      let(:pattern) { 'spec/foobar/**/*_spec.rb' }
+      let(:default_path) { 'spec/foobar' }
+
       it { is_expected.to eq ['dummy_spec'] }
     end
 
-    context '2 paths, same root' do
+    context 'multiple pattern' do
       before do
-        create_dummy_spec_files 'spec/foobar/dummy_spec.rb', 'spec/noway/other_spec.rb'
+        create_dummy_spec_files 'spec/foobar/hello1_spec.rb', 'spec/foobar/hello2_spec.rb', 'spec/foobar/bye1_spec.rb', 'spec/foobar/bye2_spec.rb'
       end
 
-      let(:pattern) { ['spec/foobar/**/*y_spec.rb', 'spec/noway/**/*_spec.rb'] }
+      let(:pattern) { %w(**/*/*1_spec.rb **/*/bye*_spec.rb) }
 
-      it { is_expected.to eq ['foobar/dummy_spec', 'noway/other_spec'] }
-    end
-
-    context '2 paths, different root' do
-      before do
-        create_dummy_spec_files 'spec/foobar/dummy_spec.rb', 'other_path/other_spec.rb'
-      end
-
-      let(:pattern) { ['spec/foobar/**/*_spec.rb', 'other_path/**/*.rb'] }
-
-      it { is_expected.to eq ['dummy_spec', 'other_spec'] }
-    end
-
-    context 'specs in different paths, same name in middle dirs' do
-      before do
-        create_dummy_spec_files 'foobar/spec/something/dummy_spec.rb', 'spec/foobar/other_spec.rb'
-      end
-
-      let(:pattern) { ['foobar/spec/**/*_spec.rb', 'spec/foobar/other_spec.rb'] }
-
-      it { is_expected.to eq ['other_spec', 'something/dummy_spec'] }
-    end
-
-    context 'absolute path and relative path that are not in the same tree' do
-      before do
-        create_dummy_spec_files 'spec/foobar/dummy_spec.rb', 'stuff/bar/other_spec.rb'
-      end
-
-      let(:files) { FileList['spec/foobar/**/*_spec.rb', 'stuff/bar/other_spec.rb'] }
-
-      it { is_expected.to eq ['dummy_spec', 'other_spec'] }
+      it { is_expected.to eq %w(foobar/bye1_spec foobar/bye2_spec foobar/hello1_spec) }
     end
 
     context 'exclude pattern' do
@@ -80,11 +62,11 @@ describe Opal::RSpec::CachedEnvironment do
       context 'single' do
         let(:exclude_pattern) { '**/*/*1_spec.rb' }
 
-        it { is_expected.to eq ['foobar/bye2_spec', 'foobar/hello2_spec'] }
+        it { is_expected.to eq %w(foobar/bye2_spec foobar/hello2_spec) }
       end
 
       context 'multiple' do
-        let(:exclude_pattern) { ['**/*/*1_spec.rb', '**/*/bye*_spec.rb' ] }
+        let(:exclude_pattern) { %w(**/*/*1_spec.rb **/*/bye*_spec.rb) }
 
         it { is_expected.to eq ['foobar/hello2_spec'] }
       end
@@ -97,7 +79,7 @@ describe Opal::RSpec::CachedEnvironment do
 
       let(:files) { FileList['spec/**/h*_spec.rb'] }
 
-      it { is_expected.to eq ['hello1_spec', 'hello2_spec'] }
+      it { is_expected.to eq %w(foobar/hello1_spec foobar/hello2_spec) }
     end
   end
 end

--- a/spec/mri/unit/opal/rspec/rake_task_spec.rb
+++ b/spec/mri/unit/opal/rspec/rake_task_spec.rb
@@ -165,8 +165,25 @@ describe Opal::RSpec::RakeTask do
 
   context 'pattern' do
     let(:task_definition) do
+      Opal::RSpec::RakeTask.new(task_name) do |_, task|
+        task.pattern = 'spec/other/**/*_spec.rb'
+      end
+    end
+
+    before do
+      create_dummy_spec_files 'spec/other/dummy_spec.rb'
+    end
+
+    it { is_expected.to have_attributes pattern: 'spec/other/**/*_spec.rb' }
+    it { is_expected.to append_opal_path 'spec' }
+    it { is_expected.to require_opal_specs eq ['other/dummy_spec'] }
+  end
+
+  context 'default path' do
+    let(:task_definition) do
       Opal::RSpec::RakeTask.new(task_name) do |server, task|
         task.pattern = 'spec/other/**/*_spec.rb'
+        task.default_path = 'spec/other'
       end
     end
 
@@ -182,7 +199,7 @@ describe Opal::RSpec::RakeTask do
 
   context 'files' do
     let(:task_definition) do
-      Opal::RSpec::RakeTask.new(task_name) do |server, task|
+      Opal::RSpec::RakeTask.new(task_name) do |_, task|
         task.files = FileList['spec/other/**/*_spec.rb']
       end
     end
@@ -192,16 +209,15 @@ describe Opal::RSpec::RakeTask do
     end
 
     it { is_expected.to have_attributes files: FileList['spec/other/**/*_spec.rb'] }
-    it { is_expected.to_not append_opal_path 'spec' }
-    it { is_expected.to append_opal_path 'spec/other' }
-    it { is_expected.to require_opal_specs eq ['dummy_spec'] }
+    it { is_expected.to append_opal_path 'spec' }
+    it { is_expected.to require_opal_specs eq ['other/dummy_spec'] }
   end
 
   context 'pattern and files' do
     let(:expected_to_run) { false }
 
     let(:task_definition) do
-      Opal::RSpec::RakeTask.new(task_name) do |server, task|
+      Opal::RSpec::RakeTask.new(task_name) do |_, task|
         task.files = FileList['spec/other/**/*_spec.rb', 'util/**/*.rb']
         task.pattern = 'spec/opal/**/*hooks_spec.rb'
       end

--- a/spec/mri/unit/opal/rspec/sprockets_environment_spec.rb
+++ b/spec/mri/unit/opal/rspec/sprockets_environment_spec.rb
@@ -6,89 +6,50 @@ describe Opal::RSpec::SprocketsEnvironment do
   include_context :temp_dir
   let(:args) { [] }
   subject(:env) { Opal::RSpec::SprocketsEnvironment.new *args }
-  
+
   RSpec::Matchers.define :have_pathnames do |expected|
-    expected = expected.map {|p| File.expand_path(p) }
-    
+    expected = expected.map { |p| File.expand_path(p) }
+
     match do |actual|
       actual == expected
     end
   end
-  
+
   describe '#cached' do
     subject { env.cached }
-    
+
     it { is_expected.to be_a ::Opal::RSpec::CachedEnvironment }
   end
-  
+
   describe '#add_spec_paths_to_sprockets' do
-    let(:args) { [pattern] }
-    
+    let(:args) { [pattern, nil, nil, default_path] }
+    let(:default_path) { nil }
+
     subject do
       # in subject to allow contexts to execute before logic
       env.add_spec_paths_to_sprockets
       env.paths.sort
     end
-        
-    context 'specs all 1 in path' do
+
+    context 'default path not set' do
       before do
         create_dummy_spec_files 'spec/foobar/dummy_spec.rb', 'spec/foobar/ignored_spec.opal'
       end
-      
+
       let(:pattern) { 'spec/foobar/**/*_spec.rb' }
-      
-      it { is_expected.to have_pathnames ['spec/foobar/'] }
-    end
-    
-    context 'multiple patterns' do
-      before do
-        create_dummy_spec_files 'spec/foobar/dummy_spec.rb', 'spec/foobar/ignored_spec.opal'
-      end
-      
-      let(:pattern) { ['spec/foobar/**/*_spec.rb', 'spec/foobar/**/*_spec.opal'] }
-      
-      it { is_expected.to have_pathnames ['spec/foobar/'] }
-    end
-    
-    context 'specs in different paths, same root' do
-      before do
-        create_dummy_spec_files 'spec/foobar/dummy_spec.rb', 'spec/noway/other_spec.rb'
-      end
-      
-      let(:pattern) { ['spec/foobar/**/*y_spec.rb', 'spec/noway/**/*_spec.rb'] }      
-      
+
       it { is_expected.to have_pathnames ['spec'] }
     end
-    
-    context 'specs in different paths, different root' do
+
+    context 'default path set' do
       before do
-        create_dummy_spec_files 'spec/foobar/dummy_spec.rb', 'other_path/other_spec.rb'
+        create_dummy_spec_files 'spec/foobar/dummy_spec.rb', 'spec/foobar/ignored_spec.opal'
       end
-      
-      let(:pattern) { ['spec/foobar/**/*_spec.rb', 'other_path/**/*.rb'] }
-      
-      it { is_expected.to have_pathnames ['other_path/', 'spec/foobar/'] }
+
+      let(:pattern) { 'spec/foobar/**/*_spec.rb' }
+      let(:default_path) { 'spec/foobar' }
+
+      it { is_expected.to have_pathnames ['spec/foobar'] }
     end
-    
-    context 'specs in different paths, same name in middle dirs' do
-      before do
-        create_dummy_spec_files 'foobar/spec/something/dummy_spec.rb', 'spec/foobar/other_spec.rb'
-      end
-      
-      let(:pattern) { ['foobar/spec/**/*_spec.rb', 'spec/foobar/other_spec.rb'] }
-      
-      it { is_expected.to have_pathnames ['foobar/spec/', 'spec/foobar'] }
-    end
-    
-    context 'absolute path and relative path that are not in the same tree' do
-      before do
-        create_dummy_spec_files 'spec/foobar/dummy_spec.rb', 'stuff/bar/other_spec.rb'
-      end
-      
-      let(:files) { FileList['spec/foobar/**/*_spec.rb', 'stuff/bar/other_spec.rb'] }
-      let(:args) { [nil, nil, files] }    
-      
-      it { is_expected.to have_pathnames ['spec/foobar', 'stuff/bar'] }      
-    end   
   end
 end

--- a/spec/rspec/core/core_spec_loader.rb
+++ b/spec/rspec/core/core_spec_loader.rb
@@ -17,6 +17,10 @@ module Opal
         [/core\/example_spec.rb/, /pending_spec.rb/]
       end
 
+      def self.default_path
+        'rspec-core/spec'
+      end
+
       def self.spec_glob
         %w{rspec-core/spec/**/*_spec.rb spec/rspec/core/opal_alternates/**/*_spec.rb}
       end

--- a/spec/rspec/expectations/expectation_spec_loader.rb
+++ b/spec/rspec/expectations/expectation_spec_loader.rb
@@ -13,6 +13,10 @@ module Opal
         'spec/rspec/expectations'
       end
 
+      def self.default_path
+        'rspec-expectations/spec'
+      end
+
       def self.spec_glob
         %w{rspec-expectations/spec/**/*_spec.rb spec/rspec/expectations/opal_alternates/**/*_spec.rb}
       end

--- a/spec/rspec/mocks/mocks_spec_loader.rb
+++ b/spec/rspec/mocks/mocks_spec_loader.rb
@@ -17,6 +17,10 @@ module Opal
         []
       end
 
+      def self.default_path
+        'rspec-mocks/spec'
+      end
+
       def self.spec_glob
         %w{rspec-mocks/spec/**/*_spec.rb}
       end

--- a/spec/rspec/support/support_spec_loader.rb
+++ b/spec/rspec/support/support_spec_loader.rb
@@ -17,6 +17,10 @@ module Opal
         [/support\/method_signature_verifier_spec.rb/]
       end
 
+      def self.default_path
+        'rspec-support/spec'
+      end
+
       def self.spec_glob
         %w{rspec-support/spec/**/*_spec.rb}
       end


### PR DESCRIPTION
Rather than trying to guess, keep it simple. Do what RSpec does and provide a facility to add 1 path to Opal's load path (spec by default, but configurable via Rake task). Anything else, it's on the user to do via Opal.append_path (equivalent to -I on rspec command line)