### PR TITLE
Remove a semicolon to fix a warning

### DIFF
--- a/lib-opal/opal/rspec/formatter/document_io.rb
+++ b/lib-opal/opal/rspec/formatter/document_io.rb
@@ -4,7 +4,7 @@ module Opal
       include IO::Writable
 
       def initialize
-        `document.open();`
+        `document.open()`
       end
 
       def close


### PR DESCRIPTION
warning: Removed semicolon ending x-string expression, interpreted as unintentional -- opal/rspec/formatter/document_io.rb:7