### PR TITLE
Don't lock rake to 12.x, ref: opal/opal-rails#119

### DIFF
--- a/opal-rspec.gemspec
+++ b/opal-rspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opal', ['>= 0.11', '< 1.1']
   spec.add_dependency 'opal-sprockets'
-  spec.add_dependency 'rake', '~> 12.0'
+  spec.add_dependency 'rake', '>= 12.0'
 
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'yard'


### PR DESCRIPTION
reference: opal/opal-rails#119