### PR TITLE
Opal 1.3 compatibility

### DIFF
--- a/lib-opal/opal/rspec/formatter/document_io.rb
+++ b/lib-opal/opal/rspec/formatter/document_io.rb
@@ -1,7 +1,7 @@
 module Opal
   module RSpec
     class DocumentIO < IO
-      include IO::Writable
+      include IO::Writable if defined? IO::Writable
 
       def initialize
         `document.open()`


### PR DESCRIPTION
Only require IO::Writable if it's available - that is - before Opal 1.3

@elia - I would propose merging this commit and releasing v0.8.0. I will work further to make an >= Opal 1.3 next iteration of opal-rspec later