### PR TITLE
Correct an async exit behavior.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,11 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        ruby: [ 2.7, 2.6, 2.5, ruby-head ]
-        opal: [ 1.0.3 ]
+        ruby: [ 3.1, "3.0", 2.7, ruby-head ]
+        opal: [ 1.0.3, 1.3, 1.5.1, master ]
 
     runs-on: ${{ matrix.os }}
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,14 @@ unless Dir['rspec{,-{core,expectations,mocks,support}}/upstream'].any?
   raise 'Run: "git submodule update --init" to get RSpec sources'
 end
 
+case ENV['OPAL_VERSION']
+when nil
+when 'master'
+  gem 'opal', git: 'https://github.com/opal/opal'
+when String
+  gem 'opal', ENV['OPAL_VERSION']
+end
+
 # These need to come from our local path in order for create_requires.rb to work properly
 gem 'rspec',              path: 'rspec/upstream'
 gem 'rspec-support',      path: 'rspec-support/upstream'

--- a/README.md
+++ b/README.md
@@ -163,11 +163,13 @@ to navigate to where an exception occurred.
 `opal-rspec` adds support for async specs to rspec. These specs can be defined using 2 approaches:
 
 1. Promises returned from subject or the `#it` block (preferred)
-1. `#async` instead of `#it` (in use with opal-rspec <= 0.4.3)
+1. `#async` instead of `#it` (in use with 0.4.3 <= opal-rspec < 0.8.0)
 
 ### Promise approach
 
 ```ruby
+require 'opal/rspec/async'
+
 describe MyClass do
   # normal example
   it 'does something' do
@@ -233,7 +235,7 @@ Limitations (apply to both async approaches):
 
 ### Async/it approach
 
-This is the approach that was supported in opal-rspec <= 0.4.3 and it still works.
+This is the approach that was supported in 0.4.3 <= opal-rspec < 0.8.0
 
 ```ruby
 describe MyClass2 do

--- a/lib-opal/opal/rspec/async.rb
+++ b/lib-opal/opal/rspec/async.rb
@@ -1,3 +1,6 @@
+module RSpec::OpalAsync
+end
+
 require 'opal/rspec/async/core_ext'
 require 'opal/rspec/async/example'
 require 'opal/rspec/async/example_group'

--- a/lib-opal/opal/rspec/async/runner.rb
+++ b/lib-opal/opal/rspec/async/runner.rb
@@ -10,7 +10,7 @@ module ::RSpec::Core
       # NOW:
       run(ARGV, $stderr, $stdout).then do |status|
         status = status.to_i
-        exit(status) if status != 0
+        exit(status)
       end
     end
 

--- a/lib-opal/opal/rspec/browser.rb
+++ b/lib-opal/opal/rspec/browser.rb
@@ -5,7 +5,7 @@ RSpec.configure do |config|
 end
 
 # Trigger #at_exit callbacks once the DOM is ready
-kernel_exit = -> _ { Kernel.exit }
+kernel_exit = -> _ { Kernel.exit unless defined? RSpec::OpalAsync }
 if JS[:document].JS[:readyState] == :complete
   JS[:setTimeOut].call(kernel_exit, 1)
 else

--- a/opal-rspec.gemspec
+++ b/opal-rspec.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'opal', ['>= 1.0.0', '< 2.0']
-  spec.add_dependency 'opal-sprockets', '< 2.0'
+  spec.add_dependency 'opal-sprockets', ['>= 1.0', '< 2.0']
   spec.add_dependency 'rake', '>= 12.0'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
* Improve documentation regarding async in README.md
* If async logic is loaded, don't automatically Kernel#exit on page load event
* Always call Kernel#exit when the tests are finished

Thanks to Brandon Gastelo for spotting this bug.